### PR TITLE
Add banner for participation request

### DIFF
--- a/src/components/SAToastNotification.vue
+++ b/src/components/SAToastNotification.vue
@@ -1,0 +1,81 @@
+<template>
+  <transition
+    enter-active-class="duration-500 ease"
+    enter-from-class="transform opacity-0"
+    leave-active-class="duration-500 ease"
+    leave-to-class="transform opacity-0"
+  >
+    <div
+      v-if="isActive"
+      class="rounded p-4 mb-2 bg-pink-600 text-white"
+    >
+      <p><b>Gestalte den Planer von morgen mit!</b></p>
+      <span v-if="!isExpanded">Wir suchen Teilnehmer für eine UX-Studie im Rahmen unserer SA zum Planer.</span>
+      <span v-if="isExpanded">
+        Für unsere SA suchen wir Teilnehmende für Interviews, Umfragen oder Tagebuchstudien.
+        Interesse? Melde dich bei uns!
+        Danke, Stefi &amp; Laura
+      </span>
+      <button
+        class="absolute right-2 top-2"
+        type="button"
+        @click="dismiss()"
+      >
+        <font-awesome-icon
+          :icon="['fa', 'circle-xmark']"
+          size="lg"
+        />
+      </button>
+      <button
+        v-if="!isExpanded"
+        class="block rounded bg-slate-200/50 py-1 px-2 mt-2 hover:bg-slate-300/50 transition-colors duration-75"
+        type="button"
+        @click="toggleExpand()"
+      >
+        Mehr
+      </button>
+      <button
+        v-if="isExpanded"
+        class="block rounded bg-slate-200/50 py-1 px-2 mt-2 hover:bg-slate-300/50 transition-colors duration-75"
+        type="button"
+        @click="participate()"
+      >
+        Teilnehmen
+      </button>
+    </div>
+  </transition>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+
+const SA_TOAST_DISMISSED_KEY = 'sa_toast_dismissed';
+
+export default defineComponent({
+  name: 'SAToastNotification',
+  data() {
+    return {
+      isActive: false,
+      isExpanded: false,
+    }
+  },
+  async mounted() {
+    const saToastDismissed = localStorage.getItem(SA_TOAST_DISMISSED_KEY);
+    this.isActive = !saToastDismissed;
+  },
+  methods: {
+    toggleExpand() {
+      this.isExpanded = !this.isExpanded;
+    },
+    dismiss() {
+      localStorage.setItem(SA_TOAST_DISMISSED_KEY, `${true}`);
+      this.isActive = false;
+    },
+    participate() {
+      /* eslint-disable-next-line max-len */
+      window.open("https://teams.microsoft.com/l/team/19%3A6zuS6jbWX4asXCCg1QzZbuFL4SC9prIAPL4haU5_bLg1%40thread.tacv2/conversations?groupId=3740cce2-50c5-4f44-9211-21f735b6c827&tenantId=a6e70fa3-1c7a-4aa2-a25e-836eea52ca22");
+    }
+  }
+});
+
+</script>

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -1,13 +1,13 @@
 <template>
   <div class="fixed top-2 right-2 z-50">
-    <ToastNoficiation
+    <ToastNotification
       v-for="message in errorMessages"
       :key="message"
       :duration="4500"
       :show-toast="true"
       :text="message"
     />
-    <ToastNoficiation
+    <ToastNotification
       :text="'Folgende Module konnten nicht wiederhergestellt werden'"
       :show-toast="unknownModules?.length != 0"
       :list-items="unknownModules.map(u => `- ${u.id} in semester ${u.semesterNumber}`)"
@@ -126,7 +126,7 @@ import {defineComponent} from 'vue';
 import SemesterComponent from '../components/Semester.vue';
 import FocusComponent from '../components/Focus.vue';
 import BeautifulProgressIndicator from '../components/BeautifulProgressIndicator.vue';
-import ToastNoficiation from '../components/ToastNotification.vue';
+import ToastNotification from '../components/ToastNotification.vue';
 import {getColorForCategoryId} from '../helpers/color-helper';
 import type {Category, Focus, Module, Semester, UnknownModule} from '../helpers/types';
 import {parseQuery} from "vue-router";
@@ -141,7 +141,7 @@ const currentSemester = SemesterInfo.now();
 
 export default defineComponent({
   name: 'Home',
-  components: {SemesterComponent, FocusComponent, BeautifulProgressIndicator, ToastNoficiation },
+  components: { SemesterComponent, FocusComponent, BeautifulProgressIndicator, ToastNotification },
   data() {
     return {
       startSemester: undefined as SemesterInfo | undefined,

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -15,6 +15,9 @@
       @on-dismiss="removeUnknownModulesFromUrl"
     />
   </div>
+  <div class="fixed top-2 right-2 ml-2 z-50 md:w-1/4">
+    <SAToastNotification />
+  </div>
   <div class="flex space-x-2 overflow-auto before:m-auto after:m-auto p-4">
     <SemesterComponent
       v-for="semester in semesters"
@@ -127,6 +130,7 @@ import SemesterComponent from '../components/Semester.vue';
 import FocusComponent from '../components/Focus.vue';
 import BeautifulProgressIndicator from '../components/BeautifulProgressIndicator.vue';
 import ToastNotification from '../components/ToastNotification.vue';
+import SAToastNotification from '../components/SAToastNotification.vue';
 import {getColorForCategoryId} from '../helpers/color-helper';
 import type {Category, Focus, Module, Semester, UnknownModule} from '../helpers/types';
 import {parseQuery} from "vue-router";
@@ -141,7 +145,7 @@ const currentSemester = SemesterInfo.now();
 
 export default defineComponent({
   name: 'Home',
-  components: { SemesterComponent, FocusComponent, BeautifulProgressIndicator, ToastNotification },
+  components: { SemesterComponent, FocusComponent, BeautifulProgressIndicator, ToastNotification, SAToastNotification },
   data() {
     return {
       startSemester: undefined as SemesterInfo | undefined,


### PR DESCRIPTION
This PR will add a banner, in which we ask for participation in the UX process of our SA.
Clicking on the "x" or "Teilnehmen" button will close the banner and - through a key in the localStorage - not show it again on the same device.