### PR TITLE
Fix Musterstudienpläne first semester always being wrong

### DIFF
--- a/src/components/Navigation.vue
+++ b/src/components/Navigation.vue
@@ -70,7 +70,7 @@ export default defineComponent({
   data() {
     return {
       isBurgerActive: false,
-      startSemesterName: SemesterInfo.lastSpringSemester().toString(),
+      startSemesterName: SemesterInfo.lastAutumnSemester().toString(),
       categories: [
         {
           title: 'Musterpläne Teilzeit',

--- a/src/components/PageFooter.vue
+++ b/src/components/PageFooter.vue
@@ -47,6 +47,7 @@ export default defineComponent({
         { name: "Vina Zahnd", githubHandle: "Venyla" },
         { name: "Linus Flury", githubHandle: "CHLinusch" },
         { name: "Marco Schneider", githubHandle: "marcoschneider" },
+        { name: "Jan Untersander", githubHandle: "Untersander" },
       ],
     },
   },

--- a/src/helpers/semester-info.ts
+++ b/src/helpers/semester-info.ts
@@ -27,6 +27,16 @@ export class SemesterInfo {
     return currentSemester.minus(1);
   }
 
+  static lastAutumnSemester() {
+    const currentSemester = SemesterInfo.now();
+
+    if (!currentSemester.isSpringSemester) {
+      return currentSemester;
+    }
+
+    return currentSemester.minus(1);
+  }
+
   static parse(text: string) {
     if (text.length !== 4) return null;
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,4 +1,4 @@
-const plugin = require('tailwindcss/plugin')
+import plugin from 'tailwindcss/plugin';
 
 /** @type {import('tailwindcss').Config} */
 export default {


### PR DESCRIPTION
First semster when choosing musterstudienplan always is current or last FS instead of HS.
Changed it to always being either current or last HS.

Also had problems with the require in the tailwind.config.js as i could not npm run build/dev so changed it to be an import statment.