### PR TITLE
Adjust touch-only media query

### DIFF
--- a/style.css
+++ b/style.css
@@ -1,6 +1,6 @@
 @import "tailwindcss";
 
-@custom-variant touch-only (@media (hover: none));
+@custom-variant touch-only (@media (hover: none) or (pointer: coarse));
 
 /* This media query applies styles only to devices that do not support hover, 
    such as touchscreens. It ensures that elements with a title attribute 


### PR DESCRIPTION
Samsung phones incorrectly report hover as being available, which leads to the "hover" media query being active. This is a problem because the delete buttons are not visible on Samsung phones.

Using `pointer: coarse` avoids this, by also showing these elements on devices without a mouse. This could negatively impact users who use a stylus, but I think it is safe to assume that we have more Samsung users than stylus users.

Relevant blog post:
https://www.ctrl.blog/entry/css-media-hover-samsung.html