### PR TITLE
fix: resolve performance issues with O(n*m) lookups and redundant computations

### DIFF
--- a/src/components/GraphModule.vue
+++ b/src/components/GraphModule.vue
@@ -123,14 +123,18 @@ export default defineComponent({
   },
   computed: {
     recommendedModules(): Module[] {
+      const moduleMap = store.getters.moduleMap as Map<string, Module>;
+      const plannedSet = store.getters.allPlannedModuleIdsSet as Set<string>;
       return this.module.recommendedModuleIds
-        .map(id => (store.getters.modules as Module[]).find(m => m.id === id))
-        .filter((m): m is Module => !!m && !(store.getters.allPlannedModuleIds as string[]).includes(m.id))
+        .map(id => moduleMap.get(id))
+        .filter((m): m is Module => !!m && !plannedSet.has(m.id))
     },
     dependentModules(): Module[] {
+      const moduleMap = store.getters.moduleMap as Map<string, Module>;
+      const plannedSet = store.getters.allPlannedModuleIdsSet as Set<string>;
       return this.module.dependentModuleIds
-        .map(id => (store.getters.modules as Module[]).find(m => m.id === id))
-        .filter((m): m is Module => !!m && !(store.getters.allPlannedModuleIds as string[]).includes(m.id))
+        .map(id => moduleMap.get(id))
+        .filter((m): m is Module => !!m && !plannedSet.has(m.id))
     },
     hasRecommended(): boolean {
       return this.recommendedModules.length > 0

--- a/src/components/GraphModuleHightlight.vue
+++ b/src/components/GraphModuleHightlight.vue
@@ -48,7 +48,7 @@ export default {
   },
   computed: {
     isPlanned(): boolean {
-      return (store.getters.allPlannedModuleIds as string[]).includes(this.id);
+      return (store.getters.allPlannedModuleIdsSet as Set<string>).has(this.id);
     },
   },
   methods: {

--- a/src/components/ModuleSearch.vue
+++ b/src/components/ModuleSearch.vue
@@ -183,6 +183,7 @@ export default defineComponent({
   data() {
     return {
       isSearching: false,
+      semesterFilterData: SEMESTER_FILTER_DATA,
       filter: {
         query: '',
         categories: [] as string[],
@@ -248,9 +249,6 @@ export default defineComponent({
       return [...new Set<number>(store.getters.modules.map(m => m.ects))]
         .sort((a, b) => a - b)
         .map(value => ({ id: value, value: value.toString() })) as { id: number, value: string }[];
-    },
-    semesterFilterData() {
-      return SEMESTER_FILTER_DATA;
     },
   },
   methods: {

--- a/src/components/ModuleSearch.vue
+++ b/src/components/ModuleSearch.vue
@@ -63,7 +63,7 @@
             <h3>Kategorie</h3>
             <ModuleFilter
               v-model:selected="filter.categories"
-              :data="categoryFilterData()"
+              :data="categoryFilterData"
               data-cy-tag="ModuleFilter-CategoryFilter"
               :is-single-select="false"
               :is-button-group="false"
@@ -74,7 +74,7 @@
             </h3>
             <ModuleFilter
               v-model:selected="filter.ects"
-              :data="ectsFilterData()"
+              :data="ectsFilterData"
               :is-single-select="false"
               data-cy-tag="ModuleFilter-EctsFilter"
               is-button-group
@@ -85,7 +85,7 @@
             </h3>
             <ModuleFilter
               v-model:selected="filter.semester"
-              :data="semesterFilterData()"
+              :data="semesterFilterData"
               data-cy-tag="ModuleFilter-SemesterFilter"
               is-single-select
               is-button-group
@@ -177,7 +177,6 @@ export default defineComponent({
   data() {
     return {
       isSearching: false,
-      isOneModuleAvailable: true,
       filter: {
         query: '',
         categories: [] as string[],
@@ -197,8 +196,8 @@ export default defineComponent({
           colorClass: getColorClassForCategoryId(c.id),
         };
       });
-      const modulesInGroups = groups.flatMap(g => g.modules).map(m => m.id);
-      const modulesNotInGroups = store.getters.modules.filter(m => !modulesInGroups.includes(m.id));
+      const modulesInGroupIds = new Set(groups.flatMap(g => g.modules).map(m => m.id));
+      const modulesNotInGroups = store.getters.modules.filter(m => !modulesInGroupIds.has(m.id));
       let filteredGroups: GroupedModule[] = groups.concat({
         id: 'none',
         name: 'Ohne',
@@ -211,48 +210,50 @@ export default defineComponent({
         filteredGroups = filteredGroups.filter(v => this.filter.categories.includes(v.id))
       }
 
-      if (this.filter.ects.length > 0) {
-        filteredGroups = filteredGroups.map(g => {
-          return {
-            ...g,
-            modules: g.modules.filter(m => this.filter.ects.includes(m.ects))
-          }
-        });
-      }
+      const ectsFilter = this.filter.ects;
+      const semesterFilter = this.filter.semester;
+      const queryFilter = this.filter.query.toLowerCase();
+      const needsModuleFilter = ectsFilter.length > 0 || semesterFilter.length > 0 || queryFilter.length > 0;
 
-      if (this.filter.semester.length > 0) {
-        filteredGroups = filteredGroups.map(g => {
-          return {
-            ...g,
-            modules: g.modules.filter(m => this.filter.semester.includes(m.term as string))
-          }
-        });
-      }
-
-      if (this.filter.query.length > 0) {
-        filteredGroups = filteredGroups.map(g => {
-          return {
-            ...g,
-            modules: g.modules.filter(m => m.name.toLowerCase().includes(this.filter.query.toLowerCase()))
-          }
-        });
+      if (needsModuleFilter) {
+        filteredGroups = filteredGroups.map(g => ({
+          ...g,
+          modules: g.modules.filter(m =>
+            (ectsFilter.length === 0 || ectsFilter.includes(m.ects)) &&
+            (semesterFilter.length === 0 || semesterFilter.includes(m.term as string)) &&
+            (queryFilter.length === 0 || m.name.toLowerCase().includes(queryFilter))
+          )
+        }));
       }
 
       return filteredGroups;
-    }
-  },
-  watch: {
-    groupedModules: {
-      handler(newValue) {
-        const modules = newValue.flatMap(g => {
-          return g.modules
-        })
-
-        this.isOneModuleAvailable = modules.length !== 0;
-      },
-      deep: true,
-      immediate: true
-    }
+    },
+    isOneModuleAvailable(): boolean {
+      return this.groupedModules.some(g => g.modules.length > 0);
+    },
+    categoryFilterData() {
+      return store.getters.enrichedCategories.map(c => ({
+        id: c.id,
+        value: c.name,
+        color: getColorClassForCategoryId(c.id)
+      }));
+    },
+    ectsFilterData() {
+      return store.getters.modules.map(m => m.ects)
+        .filter((value: number, index: number, self: number[]) => self.indexOf(value) === index)
+        .sort((a: number, b: number) => a - b)
+        .map((value: number) => ({
+          id: value,
+          value: value.toString()
+        })) as { id: number, value: string }[];
+    },
+    semesterFilterData() {
+      return [
+        { id: 'FS', value: 'Frühling' },
+        { id: 'HS', value: 'Herbst' },
+        { id: 'both', value: 'Beide' }
+      ];
+    },
   },
   methods: {
     moduleIsDisabled(module: Module): boolean {
@@ -262,7 +263,7 @@ export default defineComponent({
         (this.showNextPossibleSemester && !module.nextPossibleSemester)));
     },
     moduleIsInPlan(module: Module): boolean {
-      return store.getters.allPlannedModuleIds.includes(module.id);
+      return (store.getters.allPlannedModuleIdsSet as Set<string>).has(module.id);
     },
     moduleHasWrongTerm(module: Module): boolean {
       return ValidationHelper.isModuleInWrongTerm(module, this.termForWhichToSearch);
@@ -279,42 +280,6 @@ export default defineComponent({
         ects: [] as number[],
         semester: [] as string[],
       };
-    },
-    categoryFilterData() {
-      return store.getters.enrichedCategories.map(c => {
-        return {
-          id: c.id,
-          value: c.name,
-          color: getColorClassForCategoryId(c.id)
-        };
-      });
-    },
-    ectsFilterData() {
-      return store.getters.modules.map(m => {
-        return m.ects
-      }).filter((value: number, index: number, self: number[]) => {
-        return self.indexOf(value) === index;
-      }).sort((a: number, b: number) => a - b).map((value: number) => {
-        return {
-          id: value,
-          value: value.toString()
-        };
-      }) as { id: number, value: string }[];
-    },
-    semesterFilterData() {
-      return [
-        {
-          id: 'FS',
-          value: 'Frühling'
-        },
-        {
-          id: 'HS',
-          value: 'Herbst'
-        },
-        {
-          id: 'both',
-          value: 'Beide'
-        }];
     },
   }
 });

--- a/src/components/ModuleSearch.vue
+++ b/src/components/ModuleSearch.vue
@@ -183,7 +183,6 @@ export default defineComponent({
   data() {
     return {
       isSearching: false,
-      semesterFilterData: SEMESTER_FILTER_DATA,
       filter: {
         query: '',
         categories: [] as string[],
@@ -249,6 +248,9 @@ export default defineComponent({
       return [...new Set<number>(store.getters.modules.map(m => m.ects))]
         .sort((a, b) => a - b)
         .map(value => ({ id: value, value: value.toString() })) as { id: number, value: string }[];
+    },
+    semesterFilterData() {
+      return SEMESTER_FILTER_DATA;
     },
   },
   methods: {

--- a/src/components/ModuleSearch.vue
+++ b/src/components/ModuleSearch.vue
@@ -126,6 +126,12 @@ import ModuleFilter from "./ModuleFilter.vue";
 import ModuleSearchList from "./ModuleSearchList.vue";
 import type { GroupedModule } from "../types/GroupedModule";
 
+const SEMESTER_FILTER_DATA = [
+  { id: 'FS', value: 'Frühling' },
+  { id: 'HS', value: 'Herbst' },
+  { id: 'both', value: 'Beide' }
+];
+
 export default defineComponent({
   name: 'ModuleSearch',
   components: {
@@ -239,20 +245,12 @@ export default defineComponent({
       }));
     },
     ectsFilterData() {
-      return store.getters.modules.map(m => m.ects)
-        .filter((value: number, index: number, self: number[]) => self.indexOf(value) === index)
-        .sort((a: number, b: number) => a - b)
-        .map((value: number) => ({
-          id: value,
-          value: value.toString()
-        })) as { id: number, value: string }[];
+      return [...new Set<number>(store.getters.modules.map(m => m.ects))]
+        .sort((a, b) => a - b)
+        .map(value => ({ id: value, value: value.toString() })) as { id: number, value: string }[];
     },
     semesterFilterData() {
-      return [
-        { id: 'FS', value: 'Frühling' },
-        { id: 'HS', value: 'Herbst' },
-        { id: 'both', value: 'Beide' }
-      ];
+      return SEMESTER_FILTER_DATA;
     },
   },
   methods: {

--- a/src/components/ModuleSearchListItem.vue
+++ b/src/components/ModuleSearchListItem.vue
@@ -61,7 +61,7 @@ export default defineComponent({
   },
   methods: {
     moduleIsInPlan(module: Module): boolean {
-      return store.getters.allPlannedModuleIds.includes(module.id);
+      return (store.getters.allPlannedModuleIdsSet as Set<string>).has(module.id);
     },
     moduleIsDisabled(module: Module): boolean {
       return this.moduleIsInPlan(module) || (this.disableInvalidModules && (

--- a/src/composables/useGraphView.ts
+++ b/src/composables/useGraphView.ts
@@ -51,7 +51,7 @@ export function useGraphView() {
   }
 
   async function computeLayout() {
-    const plannedIdSet = new Set(allPlannedModuleIds.value);
+    const plannedIdSet = store.getters.allPlannedModuleIdsSet as Set<string>;
     const plannedModules = modules.value.filter((m) => plannedIdSet.has(m.id));
     const rawNodes = generateModuleNodes(plannedModules);
     const rawEdges = generateModuleEdges(

--- a/src/composables/useGraphView.ts
+++ b/src/composables/useGraphView.ts
@@ -51,7 +51,8 @@ export function useGraphView() {
   }
 
   async function computeLayout() {
-    const plannedModules = modules.value.filter((m) => allPlannedModuleIds.value.includes(m.id));
+    const plannedIdSet = new Set(allPlannedModuleIds.value);
+    const plannedModules = modules.value.filter((m) => plannedIdSet.has(m.id));
     const rawNodes = generateModuleNodes(plannedModules);
     const rawEdges = generateModuleEdges(
       plannedModules,

--- a/src/helpers/store.ts
+++ b/src/helpers/store.ts
@@ -31,14 +31,10 @@ export const store = createStore({
       state.modules.forEach(m => map.set(m.id, m));
       return map;
     },
-    modulesByIds: (_state, getters) => (moduleIds: string[]) => {
-      const map = getters.moduleMap as Map<string, Module>;
-      return moduleIds.map(id => map.get(id)).filter(f => f);
-    },
     allPlannedModuleIds: state => state.semesters
       .flatMap(semester => semester.moduleIds)
       .concat(state.accreditedModules.map(m => m.moduleId))
-      .filter(id => id),
+      .filter((id): id is string => !!id),
     allPlannedModuleIdsSet: (_state, getters) => {
       return new Set<string>(getters.allPlannedModuleIds);
     },
@@ -69,8 +65,7 @@ export const store = createStore({
         modules: category.moduleIds.map(id => map.get(id)).filter(f => f),
       }));
     },
-    enrichedFocuses: (_state, getters) => {
-      const state = store.state;
+    enrichedFocuses: (state, getters) => {
       const plannedSet = getters.allPlannedModuleIdsSet as Set<string>;
       const map = getters.moduleMap as Map<string, Module>;
       const numberOfModulesRequiredToGetFocus = 8;

--- a/src/helpers/store.ts
+++ b/src/helpers/store.ts
@@ -88,10 +88,13 @@ export const store = createStore({
             ),
             // to only show actually available modules, we filter out predecessors of already planned ones
           availableModules: focus.moduleIds
-            .filter(moduleId =>
-              !plannedSet.has(moduleId) &&
-              !plannedSet.has(allModulesForFocus.find(module => module.id === moduleId)?.successorModuleId)
-            )
+            .filter(moduleId => {
+              const successorId = allModulesForFocus.find(module => module.id === moduleId)?.successorModuleId;
+              return (
+                !plannedSet.has(moduleId) &&
+                !(successorId && plannedSet.has(successorId))
+              );
+            })
             .map(id => map.get(id))
             .filter(f => f),
           modules: allModulesForFocus,

--- a/src/helpers/store.ts
+++ b/src/helpers/store.ts
@@ -38,8 +38,8 @@ export const store = createStore({
     allPlannedModuleIdsSet: (_state, getters) => {
       return new Set<string>(getters.allPlannedModuleIds);
     },
-    totalPlannedEcts: (_state, getters) => getPlannedEcts(undefined, getters.enrichedSemesters),
-    totalEarnedEcts: (_state, getters) => getEarnedEcts(undefined, getters.enrichedSemesters),
+    totalPlannedEcts: (_state, getters) => getPlannedEcts(undefined, getters.enrichedSemesters, getters.startSemester),
+    totalEarnedEcts: (_state, getters) => getEarnedEcts(undefined, getters.enrichedSemesters, getters.startSemester, getters.accreditedModules),
     startSemester: state => state.startSemester,
     studienordnung: state => state.studienordnung,
     validationEnabled: state => state.validationEnabled,
@@ -57,10 +57,12 @@ export const store = createStore({
     enrichedCategories: (state, getters) => {
       const map = getters.moduleMap as Map<string, Module>;
       const enrichedSemesters = getters.enrichedSemesters;
+      const startSemester = getters.startSemester;
+      const accreditedModules = getters.accreditedModules;
       return state.categories.map(category => ({
         ...category,
-        earnedEcts: getEarnedEcts(category, enrichedSemesters),
-        plannedEcts: getPlannedEcts(category, enrichedSemesters),
+        earnedEcts: getEarnedEcts(category, enrichedSemesters, startSemester, accreditedModules),
+        plannedEcts: getPlannedEcts(category, enrichedSemesters, startSemester),
         colorClass: getColorClassForCategoryId(category.id),
         modules: category.moduleIds.map(id => map.get(id)).filter(f => f),
       }));
@@ -82,7 +84,7 @@ export const store = createStore({
             // to only show actually available modules, we filter out predecessors of already planned ones
           availableModules: focus.moduleIds
             .filter(moduleId => {
-              const successorId = allModulesForFocus.find(module => module.id === moduleId)?.successorModuleId;
+              const successorId = map.get(moduleId)?.successorModuleId;
               return (
                 !plannedSet.has(moduleId) &&
                 !(successorId && plannedSet.has(successorId))
@@ -220,11 +222,11 @@ export const store = createStore({
     },
   }
 });
-function getEarnedEcts(category: Category | undefined, enrichedSemesters: Semester[]): number {
-  if (store.getters.startSemester === undefined) {
+function getEarnedEcts(category: Category | undefined, enrichedSemesters: Semester[], startSemester: SemesterInfo | undefined, accreditedModules: AccreditedModule[]): number {
+  if (startSemester === undefined) {
     return 0;
   }
-  const indexOfLastCompletedSemester = SemesterInfo.now().difference(store.getters.startSemester);
+  const indexOfLastCompletedSemester = SemesterInfo.now().difference(startSemester);
 
   if (indexOfLastCompletedSemester < 0) {
     return 0;
@@ -235,19 +237,19 @@ function getEarnedEcts(category: Category | undefined, enrichedSemesters: Semest
     .flatMap((semester) => semester.modules)
     .filter((module) => !category || category.moduleIds.includes(module.id))
     .reduce((previousTotal, module) => previousTotal + module.ects, 0);
-  const accreditedEcts = store.getters.accreditedModules
+  const accreditedEcts = accreditedModules
     .filter(module => !category || module.categoryIds.includes(category.id))
     .reduce((previousTotal, module) => previousTotal + module.ects, 0);
   return ectsInSemesters + accreditedEcts;
 }
 
-function getPlannedEcts(category: Category | undefined, enrichedSemesters: Semester[]): number {
-  if (store.getters.startSemester === undefined) {
+function getPlannedEcts(category: Category | undefined, enrichedSemesters: Semester[], startSemester: SemesterInfo | undefined): number {
+  if (startSemester === undefined) {
     return 0;
   }
 
   let semestersToConsider = enrichedSemesters;
-  const indexOfLastCompletedSemester = SemesterInfo.now().difference(store.getters.startSemester);
+  const indexOfLastCompletedSemester = SemesterInfo.now().difference(startSemester);
 
   if (indexOfLastCompletedSemester >= 0) {
     semestersToConsider = semestersToConsider.slice(indexOfLastCompletedSemester)

--- a/src/helpers/store.ts
+++ b/src/helpers/store.ts
@@ -51,16 +51,14 @@ export const store = createStore({
       state.modules.map(m => m.validationInfo).filter(f => f?.severity === 'hard').length,
     hardValidationProblemsByType: state => type =>
       state.modules.map(m => m.validationInfo).filter(f => f?.severity === 'hard' && f?.type === type),
-    enrichedSemesters: (_state, getters) => {
-      const state = store.state;
+    enrichedSemesters: (state, getters) => {
       const map = getters.moduleMap as Map<string, Module>;
       return state.semesters.map(semester => ({
         ...semester,
         modules: semester.moduleIds.map(id => map.get(id)).filter(f => f),
       }));
     },
-    enrichedCategories: (_state, getters) => {
-      const state = store.state;
+    enrichedCategories: (state, getters) => {
       const map = getters.moduleMap as Map<string, Module>;
       const enrichedSemesters = getters.enrichedSemesters;
       return state.categories.map(category => ({

--- a/src/helpers/store.ts
+++ b/src/helpers/store.ts
@@ -26,14 +26,24 @@ export const store = createStore({
     semesters: state => state.semesters,
     categories: state => state.categories,
     accreditedModules: state => state.accreditedModules,
-    modulesByIds: state => moduleIds =>
-      moduleIds.map((id) => state.modules.find((module) => module.id === id)).filter(f => f),
-    totalPlannedEcts: () => getPlannedEcts(),
-    totalEarnedEcts: () => getEarnedEcts(),
+    moduleMap: state => {
+      const map = new Map<string, Module>();
+      state.modules.forEach(m => map.set(m.id, m));
+      return map;
+    },
+    modulesByIds: (_state, getters) => (moduleIds: string[]) => {
+      const map = getters.moduleMap as Map<string, Module>;
+      return moduleIds.map(id => map.get(id)).filter(f => f);
+    },
     allPlannedModuleIds: state => state.semesters
       .flatMap(semester => semester.moduleIds)
       .concat(state.accreditedModules.map(m => m.moduleId))
       .filter(id => id),
+    allPlannedModuleIdsSet: (_state, getters) => {
+      return new Set<string>(getters.allPlannedModuleIds);
+    },
+    totalPlannedEcts: (_state, getters) => getPlannedEcts(undefined, getters.enrichedSemesters),
+    totalEarnedEcts: (_state, getters) => getEarnedEcts(undefined, getters.enrichedSemesters),
     startSemester: state => state.startSemester,
     studienordnung: state => state.studienordnung,
     validationEnabled: state => state.validationEnabled,
@@ -41,43 +51,53 @@ export const store = createStore({
       state.modules.map(m => m.validationInfo).filter(f => f?.severity === 'hard').length,
     hardValidationProblemsByType: state => type =>
       state.modules.map(m => m.validationInfo).filter(f => f?.severity === 'hard' && f?.type === type),
-    enrichedCategories: (state, getters) =>
-      state.categories.map(category => ({
+    enrichedSemesters: (_state, getters) => {
+      const state = store.state;
+      const map = getters.moduleMap as Map<string, Module>;
+      return state.semesters.map(semester => ({
+        ...semester,
+        modules: semester.moduleIds.map(id => map.get(id)).filter(f => f),
+      }));
+    },
+    enrichedCategories: (_state, getters) => {
+      const state = store.state;
+      const map = getters.moduleMap as Map<string, Module>;
+      const enrichedSemesters = getters.enrichedSemesters;
+      return state.categories.map(category => ({
         ...category,
-        earnedEcts: getEarnedEcts(category),
-        plannedEcts: getPlannedEcts(category),
+        earnedEcts: getEarnedEcts(category, enrichedSemesters),
+        plannedEcts: getPlannedEcts(category, enrichedSemesters),
         colorClass: getColorClassForCategoryId(category.id),
-        modules: getters.modulesByIds(category.moduleIds),
-      })),
-    enrichedFocuses: (state, getters) => {
-      const plannedModuleIds = getters.allPlannedModuleIds;
+        modules: category.moduleIds.map(id => map.get(id)).filter(f => f),
+      }));
+    },
+    enrichedFocuses: (_state, getters) => {
+      const state = store.state;
+      const plannedSet = getters.allPlannedModuleIdsSet as Set<string>;
+      const map = getters.moduleMap as Map<string, Module>;
       const numberOfModulesRequiredToGetFocus = 8;
       return state.focuses.map(focus => {
-        const allModulesForFocus = getters.modulesByIds(focus.moduleIds);
+        const allModulesForFocus = focus.moduleIds.map(id => map.get(id)).filter(f => f) as Module[];
         return {
           ...focus,
           numberOfMissingModules:
             Math.max(
               0,
               numberOfModulesRequiredToGetFocus - focus.moduleIds.filter(moduleId =>
-                plannedModuleIds.includes(moduleId)).length
+                plannedSet.has(moduleId)).length
             ),
             // to only show actually available modules, we filter out predecessors of already planned ones
-          availableModules: getters.modulesByIds(
-            focus.moduleIds.filter(moduleId =>
-              !plannedModuleIds.includes(moduleId) &&
-              !plannedModuleIds.includes(allModulesForFocus.find(module => module.id === moduleId).successorModuleId)
+          availableModules: focus.moduleIds
+            .filter(moduleId =>
+              !plannedSet.has(moduleId) &&
+              !plannedSet.has(allModulesForFocus.find(module => module.id === moduleId)?.successorModuleId)
             )
-          ),
+            .map(id => map.get(id))
+            .filter(f => f),
           modules: allModulesForFocus,
         };
       });
     },
-    enrichedSemesters: (state, getters) =>
-      state.semesters.map(semester => ({
-        ...semester,
-        modules: getters.modulesByIds(semester.moduleIds),
-      })),
   },
   mutations: {
     setModules(state, modules: Module[]) {
@@ -204,7 +224,7 @@ export const store = createStore({
     },
   }
 });
-function getEarnedEcts(category?: Category): number {
+function getEarnedEcts(category: Category | undefined, enrichedSemesters: Semester[]): number {
   if (store.getters.startSemester === undefined) {
     return 0;
   }
@@ -214,7 +234,7 @@ function getEarnedEcts(category?: Category): number {
     return 0;
   }
 
-  const ectsInSemesters = store.getters.enrichedSemesters
+  const ectsInSemesters = enrichedSemesters
     .slice(0, indexOfLastCompletedSemester)
     .flatMap((semester) => semester.modules)
     .filter((module) => !category || category.moduleIds.includes(module.id))
@@ -225,12 +245,12 @@ function getEarnedEcts(category?: Category): number {
   return ectsInSemesters + accreditedEcts;
 }
 
-function getPlannedEcts(category?: Category): number {
+function getPlannedEcts(category: Category | undefined, enrichedSemesters: Semester[]): number {
   if (store.getters.startSemester === undefined) {
     return 0;
   }
 
-  let semestersToConsider = store.getters.enrichedSemesters;
+  let semestersToConsider = enrichedSemesters;
   const indexOfLastCompletedSemester = SemesterInfo.now().difference(store.getters.startSemester);
 
   if (indexOfLastCompletedSemester >= 0) {

--- a/src/helpers/store.ts
+++ b/src/helpers/store.ts
@@ -51,7 +51,7 @@ export const store = createStore({
       const map = getters.moduleMap as Map<string, Module>;
       return state.semesters.map(semester => ({
         ...semester,
-        modules: semester.moduleIds.map(id => map.get(id)).filter(f => f),
+        modules: semester.moduleIds.map(id => map.get(id)).filter((m): m is Module => !!m),
       }));
     },
     enrichedCategories: (state, getters) => {
@@ -64,7 +64,7 @@ export const store = createStore({
         earnedEcts: getEarnedEcts(category, enrichedSemesters, startSemester, accreditedModules),
         plannedEcts: getPlannedEcts(category, enrichedSemesters, startSemester),
         colorClass: getColorClassForCategoryId(category.id),
-        modules: category.moduleIds.map(id => map.get(id)).filter(f => f),
+        modules: category.moduleIds.map(id => map.get(id)).filter((m): m is Module => !!m),
       }));
     },
     enrichedFocuses: (state, getters) => {
@@ -72,7 +72,7 @@ export const store = createStore({
       const map = getters.moduleMap as Map<string, Module>;
       const numberOfModulesRequiredToGetFocus = 8;
       return state.focuses.map(focus => {
-        const allModulesForFocus = focus.moduleIds.map(id => map.get(id)).filter(f => f) as Module[];
+        const allModulesForFocus = focus.moduleIds.map(id => map.get(id)).filter((m): m is Module => !!m);
         return {
           ...focus,
           numberOfMissingModules:
@@ -91,7 +91,7 @@ export const store = createStore({
               );
             })
             .map(id => map.get(id))
-            .filter(f => f),
+            .filter((m): m is Module => !!m),
           modules: allModulesForFocus,
         };
       });

--- a/src/helpers/store.ts
+++ b/src/helpers/store.ts
@@ -39,7 +39,8 @@ export const store = createStore({
       return new Set<string>(getters.allPlannedModuleIds);
     },
     totalPlannedEcts: (_state, getters) => getPlannedEcts(undefined, getters.enrichedSemesters, getters.startSemester),
-    totalEarnedEcts: (_state, getters) => getEarnedEcts(undefined, getters.enrichedSemesters, getters.startSemester, getters.accreditedModules),
+    totalEarnedEcts: (_state, getters) =>
+      getEarnedEcts(undefined, getters.enrichedSemesters, getters.startSemester, getters.accreditedModules),
     startSemester: state => state.startSemester,
     studienordnung: state => state.studienordnung,
     validationEnabled: state => state.validationEnabled,
@@ -222,7 +223,12 @@ export const store = createStore({
     },
   }
 });
-function getEarnedEcts(category: Category | undefined, enrichedSemesters: Semester[], startSemester: SemesterInfo | undefined, accreditedModules: AccreditedModule[]): number {
+function getEarnedEcts(
+  category: Category | undefined,
+  enrichedSemesters: Semester[],
+  startSemester: SemesterInfo | undefined,
+  accreditedModules: AccreditedModule[],
+): number {
   if (startSemester === undefined) {
     return 0;
   }
@@ -243,7 +249,11 @@ function getEarnedEcts(category: Category | undefined, enrichedSemesters: Semest
   return ectsInSemesters + accreditedEcts;
 }
 
-function getPlannedEcts(category: Category | undefined, enrichedSemesters: Semester[], startSemester: SemesterInfo | undefined): number {
+function getPlannedEcts(
+  category: Category | undefined,
+  enrichedSemesters: Semester[],
+  startSemester: SemesterInfo | undefined,
+): number {
   if (startSemester === undefined) {
     return 0;
   }

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -195,9 +195,9 @@ export default defineComponent({
   watch: {
     $route: {
       handler() {
-        setTimeout(() => {
+        this.$nextTick(() => {
           this.getPlanDataFromUrl();
-        }, 0);
+        });
       },
     },
   },


### PR DESCRIPTION
## Summary

Replaces O(n) array lookups with O(1) Map/Set equivalents across the store and components, eliminates redundant computations, and fixes a pre-existing null-safety bug.

### Store (`src/helpers/store.ts`)
- Added `moduleMap` getter — a `Map<string, Module>` keyed by ID, replacing O(n) `Array.find` calls throughout
- Added `allPlannedModuleIdsSet` getter — a `Set<string>` of all planned module IDs, replacing O(n) `Array.includes` calls throughout
- Removed unused `modulesByIds` getter
- Fixed `allPlannedModuleIds` filter to use a type-guard (`.filter((id): id is string => !!id)`) so the array and derived Set are truly `string[]`
- `enrichedSemesters`, `enrichedCategories`, `enrichedFocuses`: use `moduleMap.get()` for O(1) lookups and use the Vuex `state` parameter instead of accessing `store.state` directly
- `enrichedFocuses`: fixed null-safety bug — `successorModuleId` can be `null`/`undefined`, now guarded before being passed to `Set.has()`
- `getPlannedEcts` / `getEarnedEcts`: accept `enrichedSemesters` as a parameter instead of re-reading it from `store.getters`, avoiding redundant recomputation

### Components
- `GraphModule.vue`: `recommendedModules` and `dependentModules` use `moduleMap.get()` and `allPlannedModuleIdsSet.has()`
- `GraphModuleHightlight.vue`, `ModuleSearchListItem.vue`: `isPlanned` / `moduleIsInPlan` use `allPlannedModuleIdsSet.has()`
- `ModuleSearch.vue`:
  - `categoryFilterData`, `ectsFilterData`, `semesterFilterData` moved from methods to computed properties to enable Vue caching
  - `semesterFilterData` backed by a module-level constant (data never changes)
  - `ectsFilterData` deduplication changed from O(n²) `indexOf` to O(n) `new Set()`
  - `isOneModuleAvailable` converted from a deep-watched data property to a `computed` using `some()`
  - Three sequential module filter passes (ECTS, semester, query) collapsed into one
  - `modulesInGroupIds` uses a `Set` for O(1) membership check

### Composable / View
- `useGraphView.ts`: `computeLayout` builds a local `Set` from `allPlannedModuleIds` for the filter instead of O(n) `Array.includes`
- `Home.vue`: replaced `setTimeout(() => {}, 0)` with `this.$nextTick()` for correct Vue timing semantics